### PR TITLE
Add shared resources section referencing flowchart from main CSL repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # CSL_AQS_ESP32_V1
 CSL code for the AQS system running with an Adafruit Feather ESP32 V2
+### ESP32 Provisioning Flowchart
+
+<div align="center">
+  <img src="https://github.com/Community-Sensor-Lab/Air-Quality-Sensor/raw/main/images/esp32_provisioning_flowchart.JPG" width="80%"/>
+</div>
+
+*Contributed by Fahmin — hosted in [Air-Quality-Sensor](https://github.com/Community-Sensor-Lab/Air-Quality-Sensor)*
+
+### 🔗 Shared Resources
+
+This repository builds on shared documentation and assets from the [Community Sensor Lab Air-Quality-Sensor project](https://github.com/Community-Sensor-Lab/Air-Quality-Sensor). Key resources include:
+
+- 📊 **ESP32 Provisioning Flowchart** — [View image](https://github.com/Community-Sensor-Lab/Air-Quality-Sensor/raw/main/images/esp32_provisioning_flowchart.JPG)  
+  *Contributed by Fahmin, hosted in the main CSL repo*
+
+


### PR DESCRIPTION
This PR updates the README to include a Shared Resources section linking to the ESP32 provisioning flowchart hosted in the main CSL repo. The flowchart was contributed by Fahmin and helps unify onboarding across Feather M0 and ESP32 boards.

Changes include:
- Embedded flowchart image via cross-repo link
- Contributor credit for Fahmin
- Modular reference to shared documentation in Community-Sensor-Lab/Air-Quality-Sensor

This improves reproducibility and onboarding clarity for ESP32 users.
Thanks to @Fahmin for contributing the ESP32 provisioning flowchart—this addition helps unify documentation across CSL sensor builds. 